### PR TITLE
Log status code 503 as warning instead of error

### DIFF
--- a/helper.go
+++ b/helper.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	"github.com/snabble/go-logging/v2/tracex"
 )
 
@@ -90,7 +91,7 @@ func accessLogLevelFor(level logrus.Level, r *http.Request, statusCode int) logr
 			return logrus.DebugLevel
 		}
 		return level
-	} else if statusCode >= 400 && statusCode <= 499 {
+	} else if (statusCode >= 400 && statusCode <= 499) || statusCode == 503 {
 		return logrus.WarnLevel
 	}
 	return logrus.ErrorLevel


### PR DESCRIPTION
If the server is using a timeout handler, it will respond with 503. As this can be triggered by any client cancel, we should not log to error.

See https://adam-p.ca/blog/2022/01/golang-http-server-timeouts/ for more background reading. Note in particular:

> It seems like “408 Request Timeout” would be a more semantically appropriate response. We could intercept the response write to change that code, but it would get hack-y to distinguish between http.TimeoutHandler returning 503 and, say, our Ping endpoint returning it intentionally. Additionally, returning a 5xx error means that our clients will automatically retry the request, which is a good thing (probably).
