### PR TITLE
send a 500 Internal server error on recovering a panic in log middleware

### DIFF
--- a/log_middleware_test.go
+++ b/log_middleware_test.go
@@ -79,8 +79,11 @@ func Test_LogMiddleware_Panic(t *testing.T) {
 	}))
 
 	r, _ := http.NewRequest(http.MethodGet, "http://www.example.org/foo", nil)
+	resp := httptest.NewRecorder()
 
-	lm.ServeHTTP(httptest.NewRecorder(), r)
+	lm.ServeHTTP(resp, r)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
 
 	data := logRecordFromBuffer(b)
 
@@ -101,8 +104,11 @@ func Test_LogMiddleware_Panic_ErrAbortHandler(t *testing.T) {
 	}))
 
 	r, _ := http.NewRequest(http.MethodGet, "http://www.example.org/foo", nil)
+	resp := httptest.NewRecorder()
 
-	lm.ServeHTTP(httptest.NewRecorder(), r)
+	lm.ServeHTTP(resp, r)
+
+	assert.Equal(t, http.StatusInternalServerError, resp.Result().StatusCode)
 
 	data := logRecordFromBuffer(b)
 


### PR DESCRIPTION
It does not feel right to decide the statusCode in a log middleware but in this case i think it is warranted.
The alternative would be to move it to an extra layer which seems a bit over the top for now.