### PR TITLE
Allow passing multiple objects to With

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -54,8 +54,8 @@ func (logger *Logger) WithFields(fields logrus.Fields) *Entry {
 	return NewEntry(logger).WithFields(fields)
 }
 
-func (logger *Logger) With(o Identifiable) *Entry {
-	return NewEntry(logger).With(o)
+func (logger *Logger) With(os ...Identifiable) *Entry {
+	return NewEntry(logger).With(os...)
 }
 
 func (logger *Logger) WithTime(t time.Time) *Entry {
@@ -119,8 +119,17 @@ func (entry *Entry) WithFields(fields logrus.Fields) *Entry {
 	return wrapEntry(entry.Entry.WithFields(fields))
 }
 
-func (entry *Entry) With(o Identifiable) *Entry {
-	return wrapEntry(entry.Entry.WithFields(o.LogIdentity()))
+func (entry *Entry) With(os ...Identifiable) *Entry {
+	merged := map[string]any{}
+
+	for _, o := range os {
+		fields := o.LogIdentity()
+		for k, v := range fields {
+			merged[k] = v
+		}
+	}
+
+	return wrapEntry(entry.Entry.WithFields(merged))
 }
 
 func (entry *Entry) WithTime(t time.Time) *Entry {


### PR DESCRIPTION
This allow simplifying log statements like

```
logging.Log.With(checkout).With(payment).Error(...)
```
to
```
logging.Log.With(checkout, payment).Error(...)
```
