### PR TITLE
Fix panic if `nil` is passed to `With` method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/snabble/go-logging/v2
 
-go 1.22
-toolchain go1.22.5
+go 1.22.0
+
+toolchain go1.24.2
 
 require (
 	github.com/samber/lo v1.49.1

--- a/logger.go
+++ b/logger.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/sirupsen/logrus"
 )
 
@@ -128,6 +129,9 @@ func (entry *Entry) With(os ...Identifiable) *Entry {
 	merged := map[string]any{}
 
 	for _, o := range os {
+		if lo.IsEmpty(o) {
+			continue
+		}
 		fields := o.LogIdentity()
 		for k, v := range fields {
 			merged[k] = v

--- a/logger_test.go
+++ b/logger_test.go
@@ -106,6 +106,12 @@ func Test_Logger_With_MergesMultipleObjects(t *testing.T) {
 	a.Contains(out.String(), "field=__value__")
 }
 
+func Test_Logger_With_HandleNil(t *testing.T) {
+	logger := Logger{Logger: logrus.New()}
+
+	logger.With(nil).Info("message")
+}
+
 func Test_Logger_Call(t *testing.T) {
 	a := assert.New(t)
 


### PR DESCRIPTION
We did not handle passing `nil` to the `With()` method correctly. 
It resulted in a panic. Now the element is skipped if empty or nil.