### PR TITLE
Add response and payload fields

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -20,6 +20,8 @@ const (
 	DurationField       = "duration"
 	FlakyField          = "flaky"
 	TypeField           = "type"
+	ResponseField       = "response"
+	PayloadField        = "payload"
 
 	TypeDeprecation = "deprecation"
 	TypeCall        = "call"


### PR DESCRIPTION
These should be used when we need to log the body of an http request (payload) or the body of a http response (response)