### PR TITLE
Add Component option to slog package

### DIFF
--- a/slog/handler.go
+++ b/slog/handler.go
@@ -66,11 +66,6 @@ func New(opts ...OptionFunc) *slog.Logger {
 	return slog.New(o.newLogrusHandler())
 }
 
-// deprecated: use New with WithLevel instead
-func NewWithLevel(level logrus.Level) *slog.Logger {
-	return New(WithLevel(level))
-}
-
 func (o Option) newLogrusHandler() slog.Handler {
 	if o.AttrFromContext == nil {
 		o.AttrFromContext = []func(ctx context.Context) []slog.Attr{}

--- a/slog/handler.go
+++ b/slog/handler.go
@@ -31,6 +31,7 @@ type Option struct {
 	AttrFromContext []func(ctx context.Context) []slog.Attr
 	AddSource       bool
 	ReplaceAttr     func(groups []string, a slog.Attr) slog.Attr
+	Component       string // if set, this will be added as an attribute with key "component" to all log entries created by this handler
 }
 
 type OptionFunc func(*Option)
@@ -47,6 +48,12 @@ func WithMaxLevel(level logrus.Level) OptionFunc {
 	}
 }
 
+func WithComponent(component string) OptionFunc {
+	return func(o *Option) {
+		o.Component = component
+	}
+}
+
 func New(opts ...OptionFunc) *slog.Logger {
 	o := Option{
 		Level:  logLevelsToSlog[logging.Log.GetLevel()],
@@ -59,12 +66,9 @@ func New(opts ...OptionFunc) *slog.Logger {
 	return slog.New(o.newLogrusHandler())
 }
 
+// deprecated: use New with WithLevel instead
 func NewWithLevel(level logrus.Level) *slog.Logger {
-	return slog.New(
-		Option{
-			Level:  logLevelsToSlog[level],
-			Logger: logging.Log,
-		}.newLogrusHandler())
+	return New(WithLevel(level))
 }
 
 func (o Option) newLogrusHandler() slog.Handler {
@@ -97,6 +101,10 @@ func (h *LogrusHandler) Handle(ctx context.Context, record slog.Record) error {
 
 	fromContext := contextExtractor(ctx, h.option.AttrFromContext)
 	args := convert(h.option.AddSource, h.option.ReplaceAttr, append(h.attrs, fromContext...), h.groups, &record)
+
+	if h.option.Component != "" {
+		args["component"] = h.option.Component
+	}
 
 	logging.NewEntry(h.option.Logger).
 		WithContext(ctx).

--- a/slog/handler_test.go
+++ b/slog/handler_test.go
@@ -38,7 +38,7 @@ func Test_Slog_WithLevel(t *testing.T) {
 	b := bytes.NewBuffer(nil)
 	logging.Log.Out = b
 
-	slog := NewWithLevel(logrus.WarnLevel)
+	slog := New(WithLevel(logrus.WarnLevel))
 
 	// when: I log something
 	slog.Info("should be ignored ..")


### PR DESCRIPTION
This will allow us to easily filter out logs from libraries like riverqueue that take a slog.Logger